### PR TITLE
make extract toc protected

### DIFF
--- a/guides/src/main/java/io/micronaut/guides/core/DefaultWebsiteGenerator.java
+++ b/guides/src/main/java/io/micronaut/guides/core/DefaultWebsiteGenerator.java
@@ -277,7 +277,7 @@ public class DefaultWebsiteGenerator implements WebsiteGenerator {
         saveToFile(optionHtml, outputDirectory, guideOptionHtmlFileName);
     }
 
-    private List<String> extractToc(String html) {
+    protected List<String> extractToc(String html) {
         List<String> tocDivs = new ArrayList<>();
         String openDivPattern = "<div";
         String closeDivPattern = "</div>";


### PR DESCRIPTION
Needed to override in GDK because guides such as https://graal.cloud/gdk/vscode-tools/graal-cloud-native-launcher/ have a weird custom sidebar